### PR TITLE
Update ARUWPMarker.cs

### DIFF
--- a/ARToolKitUWP-Unity/Scripts/ARUWPMarker.cs
+++ b/ARToolKitUWP-Unity/Scripts/ARUWPMarker.cs
@@ -358,7 +358,7 @@ public class ARUWPMarker : MonoBehaviour{
             Debug.Log(TAG + ": not able to find ARUWPController");
             Application.Quit();
         }
-        holoLensCamera = GameObject.Find("Main Camera");
+        holoLensCamera = GameObject.FindWithTag("MainCamera");
         if (holoLensCamera == null) {
             Debug.Log(TAG + ": Main Camera does not exist in the scene");
             Application.Quit();


### PR DESCRIPTION
Doesn't force naming conventions in object hirarchy and works out of the box with the HoloToolkit.